### PR TITLE
docs: Add Capacitor 5 to support table

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ iOS only but with web fallback for development purposes.
 
 | Capacitor version | Plugin version                                    |
 | ---------- | ----------------------------------------- |
+| 5.x | >= 2.0.2 |
 | 4.x | >= 2.0.2 |
 | 3.x | >= 2.0.0 |
 | < 3.0.0 | 1.x.x |
@@ -49,8 +50,6 @@ This message can be provided in multiple languages by using a `InfoPlist.strings
 ## Usage
 
 ```typescript
-import 'capacitor-plugin-app-tracking-transparency'; // only if you want web support
-
 import {
   AppTrackingTransparency,
   AppTrackingStatusResponse,


### PR DESCRIPTION
Also removed the `import 'capacitor-plugin-app-tracking-transparency';` line because that's not needed since Capacitor 3, can be tested on https://github.com/mahnuh/capacitor-plugin-app-tracking-transparency-demo-app, run the app on web and see that it works despite that line is not part of the app.